### PR TITLE
Fix scrolling methods

### DIFF
--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -211,6 +211,7 @@ class BigList extends PureComponent {
         sectionFooterHeight,
         insetTop,
         insetBottom,
+        numColumns
       } = this.props;
       const itemHeight = this.getItemHeight();
       const sectionLengths = this.getSectionLengths();
@@ -224,6 +225,7 @@ class BigList extends PureComponent {
         insetTop,
         insetBottom,
         scrollView,
+        numColumns
       });
     }
     return null;


### PR DESCRIPTION
Fixes #17 

The `scrollToPosition` of `BigListProcessor` requires a valid numerical value for `numColumns` otherwise the `scrollTop` value results in `NaN` and no scroll operation is performed.

This fix updates the BigList component to make sure it is passing the `numColumns` prop to the processor to prevent this error.