### PR TITLE
Allow full control of item render

### DIFF
--- a/docs/docs/props.md
+++ b/docs/docs/props.md
@@ -54,6 +54,25 @@ You need also to specify the height using [**itemHeight**](#required-itemheight)
 | -------- | -------- |
 | function | Yes      |
 
+### `controlItemRender`
+
+Removes the wrapping view component that is added by BigList.
+
+Using `controlItemRender` will add more arguments to `renderItem`.
+
+
+```ts
+renderItem({ item: unknown, index: number, section: number, key: string, style: object });
+```
+
+:::note
+You will need to apply `style` to your rendered `View` for this to work properly.
+:::
+
+| Type     | Required | Default |
+| -------- | -------- | ------- |
+| boolean  | No       | `false` |
+
 ### <small class="required">Required</small> `itemHeight`
 
 Specify the item height.

--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -658,6 +658,7 @@ class BigList extends PureComponent {
       hideHeaderOnEmpty,
       hideFooterOnEmpty,
       columnWrapperStyle,
+      controlItemRender,
       placeholder,
       placeholderComponent,
       placeholderImage,
@@ -767,23 +768,46 @@ class BigList extends PureComponent {
               numColumns > 1
                 ? mergeViewStyle(itemStyle, columnWrapperStyle || {})
                 : itemStyle;
+            const width = 100 / numColumns + "%";
+
             if (this.hasSections()) {
-              child = renderItem({ item, section, index });
+              child = renderItem({
+                item,
+                section,
+                index,
+                key: uniqueKey,
+                style: mergeViewStyle(style, {
+                  height,
+                  width,
+                }),
+              });
             } else {
-              child = renderItem({ item, index });
+              child = renderItem({
+                item,
+                index,
+                key: uniqueKey,
+                style: mergeViewStyle(style, {
+                  height,
+                  width,
+                }),
+              });
             }
           }
           if (child != null) {
             children.push(
-              <BigListItem
-                key={itemKey}
-                uniqueKey={uniqueKey}
-                height={height}
-                width={100 / numColumns + "%"}
-                style={style}
-              >
-                {child}
-              </BigListItem>,
+              type === BigListItemType.ITEM && controlItemRender ? (
+                child
+              ) : (
+                <BigListItem
+                  key={itemKey}
+                  uniqueKey={uniqueKey}
+                  height={height}
+                  width={100 / numColumns + "%"}
+                  style={style}
+                >
+                  {child}
+                </BigListItem>
+              ),
             );
           }
           break;
@@ -1020,6 +1044,7 @@ BigList.propTypes = {
     right: PropTypes.number,
     top: PropTypes.number,
   }),
+  controlItemRender: PropTypes.bool,
   data: PropTypes.array,
   placeholder: PropTypes.bool,
   placeholderImage: PropTypes.any,
@@ -1128,6 +1153,7 @@ BigList.defaultProps = {
   hideMarginalsOnEmpty: false,
   hideFooterOnEmpty: false,
   hideHeaderOnEmpty: false,
+  controlItemRender: false,
   // Height
   itemHeight: 50,
   headerHeight: 0,

--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -768,7 +768,6 @@ class BigList extends PureComponent {
               numColumns > 1
                 ? mergeViewStyle(itemStyle, columnWrapperStyle || {})
                 : itemStyle;
-            const width = 100 / numColumns + "%";
 
             const renderArguments = {
               item,
@@ -785,7 +784,7 @@ class BigList extends PureComponent {
               renderArguments.key = uniqueKey;
               renderArguments.style = mergeViewStyle(style, {
                 height,
-                width,
+                width: 100 / numColumns + "%",
               });
             }
             child = renderItem(renderArguments);

--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -770,28 +770,25 @@ class BigList extends PureComponent {
                 : itemStyle;
             const width = 100 / numColumns + "%";
 
+            const renderArguments = {
+              item,
+              index,
+              section: undefined,
+              key: undefined,
+              style: undefined,
+            };
+
             if (this.hasSections()) {
-              child = renderItem({
-                item,
-                section,
-                index,
-                key: uniqueKey,
-                style: mergeViewStyle(style, {
-                  height,
-                  width,
-                }),
-              });
-            } else {
-              child = renderItem({
-                item,
-                index,
-                key: uniqueKey,
-                style: mergeViewStyle(style, {
-                  height,
-                  width,
-                }),
+              renderArguments.section = section;
+            }
+            if (controlItemRender) {
+              renderArguments.key = uniqueKey;
+              renderArguments.style = mergeViewStyle(style, {
+                height,
+                width,
               });
             }
+            child = renderItem(renderArguments);
           }
           if (child != null) {
             children.push(

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -2,12 +2,20 @@ import React, { PureComponent } from "react";
 import {
   Animated,
   LayoutChangeEvent,
-  ListRenderItem,
+  ListRenderItemInfo,
   NativeScrollEvent,
   NativeSyntheticEvent,
   ScrollViewProps,
   ViewStyle,
 } from "react-native";
+
+export type BigListRenderItem<ItemT> = (
+  info: ListRenderItemInfo<ItemT> & {
+    section?: number;
+    key?: string;
+    style?: ViewStyle | ViewStyle[];
+  },
+) => React.ReactElement | null;
 
 interface BigListProps<ItemT> extends ScrollViewProps {
   inverted: bool | null | undefined;
@@ -62,7 +70,7 @@ interface BigListProps<ItemT> extends ScrollViewProps {
   renderEmpty?: () => React.ReactNode | null | undefined;
   renderFooter?: () => React.ReactNode | null | undefined;
   renderHeader?: () => React.ReactNode | null | undefined;
-  renderItem: ListRenderItem<ItemT> | null | undefined;
+  renderItem: BigListRenderItem<ItemT> | null | undefined;
   renderSectionHeader?: (section: number) => React.ReactNode | null | undefined;
   renderSectionFooter?: (section: number) => React.ReactNode | null | undefined;
   refreshing?: boolean | null | undefined;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -18,8 +18,8 @@ export type BigListRenderItem<ItemT> = (
 ) => React.ReactElement | null;
 
 interface BigListProps<ItemT> extends ScrollViewProps {
-  inverted: bool | null | undefined;
-  horizontal: bool | null | undefined;
+  inverted?: bool | null | undefined;
+  horizontal?: bool | null | undefined;
   actionSheetScrollRef?: any | null | undefined;
   batchSizeThreshold?: number | null | undefined;
   contentInset?: {
@@ -40,7 +40,7 @@ interface BigListProps<ItemT> extends ScrollViewProps {
   hideFooterOnEmpty?: boolean | null | undefined;
   insetBottom?: number;
   insetTop?: number;
-  itemHeight?:
+  itemHeight:
     | string
     | number
     | ((item: { index: number; section?: number }) => number);
@@ -79,7 +79,7 @@ interface BigListProps<ItemT> extends ScrollViewProps {
   sectionFooterHeight?: string | number | ((section: number) => number);
   sectionHeaderHeight?: string | number | ((section: number) => number);
   sections?: ItemT[][] | null | undefined;
-  stickySectionHeadersEnabled: boolean;
+  stickySectionHeadersEnabled?: boolean;
   children?: null | undefined;
 }
 export default class BigList<ItemT = any> extends PureComponent<


### PR DESCRIPTION
The main use case is I need `onLayout` for each of the items rendered. This PR adds a new prop `controlItemRender` that bypasses `BigListItem` so that the item returned from `renderItem` is what is actually rendered in the scroll view so `onLayout` will be correct relative to the scroll view.