### PR TITLE
Remove redundant props, reuse types from FlatListProps + ListViewProps, export BigListRenderItemInfo

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,10 @@
+/* eslint-disable no-undef */
 import React, { PureComponent } from "react";
 import {
   Animated,
+  FlatListProps,
   ListRenderItemInfo,
+  ListViewProps,
   NativeScrollEvent,
   NativeSyntheticEvent,
   ScrollViewProps,
@@ -16,7 +19,31 @@ export type BigListRenderItem<ItemT> = (
   },
 ) => React.ReactElement | null;
 
-interface BigListProps<ItemT> extends ScrollViewProps {
+interface BigListProps<ItemT>
+  extends ScrollViewProps,
+    Pick<
+      FlatListProps<ItemT>,
+      | "ListEmptyComponent"
+      | "ListFooterComponent"
+      | "ListFooterComponentStyle"
+      | "ListHeaderComponent"
+      | "ListHeaderComponentStyle"
+      | "getItemLayout"
+      | "numColumns"
+      | "keyExtractor"
+      | "onEndReached"
+      | "onEndReachedThreshold"
+      | "onRefresh"
+      | "onViewableItemsChanged"
+      | "columnWrapperStyle"
+      | "refreshing"
+      | "initialScrollIndex"
+      | "removeClippedSubviews"
+    >,
+    Pick<
+      ListViewProps,
+      "renderFooter" | "renderHeader" | "stickySectionHeadersEnabled"
+    > {
   inverted?: boolean | null | undefined;
   actionSheetScrollRef?: any | null | undefined;
   batchSizeThreshold?: number | null | undefined;
@@ -25,7 +52,6 @@ interface BigListProps<ItemT> extends ScrollViewProps {
   placeholderImage?: any;
   placeholderComponent?: React.ReactNode;
   footerHeight?: string | number | (() => number);
-  getItemLayout?: () => number;
   headerHeight?: string | number | (() => number);
   hideMarginalsOnEmpty?: boolean | null | undefined;
   hideHeaderOnEmpty?: boolean | null | undefined;
@@ -36,33 +62,13 @@ interface BigListProps<ItemT> extends ScrollViewProps {
     | string
     | number
     | ((item: { index: number; section?: number }) => number);
-  keyExtractor?: (item: ItemT, index: number) => string | null | undefined;
-  ListEmptyComponent?: React.ReactNode;
-  ListFooterComponent?: React.ReactNode;
-  ListFooterComponentStyle?: ViewStyle | ViewStyle[];
-  ListHeaderComponent?: React.ReactNode;
-  ListHeaderComponentStyle?: ViewStyle | ViewStyle[];
-  numColumns?: number | null | undefined;
-  columnWrapperStyle?: ViewStyle | ViewStyle[];
-  onEndReached?:
-    | ((info: { distanceFromEnd: number }) => void)
-    | null
-    | undefined;
-  onEndReachedThreshold?: number | null | undefined;
-  onRefresh?: () => void | null | undefined;
-  onViewableItemsChanged?: () => any;
   onScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
-  removeClippedSubviews?: boolean;
   renderAccessory?: (list: React.ReactNode) => React.ReactNode;
   renderScrollViewWrapper?: (element: React.ReactNode) => React.ReactNode;
   renderEmpty?: () => React.ReactNode | null | undefined;
-  renderFooter?: () => React.ReactNode | null | undefined;
-  renderHeader?: () => React.ReactNode | null | undefined;
   renderItem: BigListRenderItem<ItemT> | null | undefined;
   renderSectionHeader?: (section: number) => React.ReactNode | null | undefined;
   renderSectionFooter?: (section: number) => React.ReactNode | null | undefined;
-  refreshing?: boolean | null | undefined;
-  initialScrollIndex?: number;
   sectionFooterHeight?: string | number | ((section: number) => number);
   sectionHeaderHeight?: string | number | ((section: number) => number);
   sections?: ItemT[][] | null | undefined;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -11,12 +11,14 @@ import {
   ViewStyle,
 } from "react-native";
 
+export type BigListRenderItemInfo<ItemT> = ListRenderItemInfo<ItemT> & {
+  section?: number;
+  key?: string;
+  style?: ViewStyle | ViewStyle[];
+};
+
 export type BigListRenderItem<ItemT> = (
-  info: ListRenderItemInfo<ItemT> & {
-    section?: number;
-    key?: string;
-    style?: ViewStyle | ViewStyle[];
-  },
+  info: BigListRenderItemInfo<ItemT>,
 ) => React.ReactElement | null;
 
 interface BigListProps<ItemT>

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,7 +1,6 @@
 import React, { PureComponent } from "react";
 import {
   Animated,
-  LayoutChangeEvent,
   ListRenderItemInfo,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -18,16 +17,9 @@ export type BigListRenderItem<ItemT> = (
 ) => React.ReactElement | null;
 
 interface BigListProps<ItemT> extends ScrollViewProps {
-  inverted?: bool | null | undefined;
-  horizontal?: bool | null | undefined;
+  inverted?: boolean | null | undefined;
   actionSheetScrollRef?: any | null | undefined;
   batchSizeThreshold?: number | null | undefined;
-  contentInset?: {
-    bottom?: number;
-    left?: number;
-    right?: number;
-    top?: number;
-  };
   data?: ItemT[];
   placeholder?: boolean;
   placeholderImage?: any;
@@ -44,8 +36,6 @@ interface BigListProps<ItemT> extends ScrollViewProps {
     | string
     | number
     | ((item: { index: number; section?: number }) => number);
-  keyboardDismissMode?: "none" | "interactive" | "on-drag";
-  keyboardShouldPersistTaps?: boolean | "always" | "never" | "handled";
   keyExtractor?: (item: ItemT, index: number) => string | null | undefined;
   ListEmptyComponent?: React.ReactNode;
   ListFooterComponent?: React.ReactNode;
@@ -59,10 +49,8 @@ interface BigListProps<ItemT> extends ScrollViewProps {
     | null
     | undefined;
   onEndReachedThreshold?: number | null | undefined;
-  onLayout?: (event: LayoutChangeEvent) => void;
   onRefresh?: () => void | null | undefined;
   onViewableItemsChanged?: () => any;
-  onScroll?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   onScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   removeClippedSubviews?: boolean;
   renderAccessory?: (list: React.ReactNode) => React.ReactNode;
@@ -74,7 +62,6 @@ interface BigListProps<ItemT> extends ScrollViewProps {
   renderSectionHeader?: (section: number) => React.ReactNode | null | undefined;
   renderSectionFooter?: (section: number) => React.ReactNode | null | undefined;
   refreshing?: boolean | null | undefined;
-  scrollEventThrottle?: number;
   initialScrollIndex?: number;
   sectionFooterHeight?: string | number | ((section: number) => number);
   sectionHeaderHeight?: string | number | ((section: number) => number);

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -67,6 +67,7 @@ interface BigListProps<ItemT>
   renderScrollViewWrapper?: (element: React.ReactNode) => React.ReactNode;
   renderEmpty?: () => React.ReactNode | null | undefined;
   renderItem: BigListRenderItem<ItemT> | null | undefined;
+  controlItemRender?: boolean;
   renderSectionHeader?: (section: number) => React.ReactNode | null | undefined;
   renderSectionFooter?: (section: number) => React.ReactNode | null | undefined;
   sectionFooterHeight?: string | number | ((section: number) => number);


### PR DESCRIPTION
This PR:
- remove duplicated props already included in ScrollViewProps
- reuse types from FlatListProps and ListViewProps. Why? To keep up to date with React Native and also receive hints/comments in IDE
![image](https://user-images.githubusercontent.com/40987398/135389054-b4e95c1a-4d4c-4267-8fcb-4f10e5537217.png)
- Add missing prop: controlItemRender
- Export `BigListRenderItemInfo` (similar to Flatlist's `ListRenderItemInfo`)
Thanks!