### PR TITLE
chore: move yarpm to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,8 @@
     "prettier": "^2.4.1",
     "react-native-builder-bob": "^0.18.2",
     "standard-version": "^9.3.2",
-    "typescript": "^4.5.2"
+    "typescript": "^4.5.2",
+    "yarpm": "^1.1.1"
   },
   "husky": {
     "hooks": {
@@ -87,7 +88,6 @@
   },
   "dependencies": {
     "prop-types": "^15.7.2",
-    "yarpm": "^1.1.1"
   },
   "bit": {
     "env": {},


### PR DESCRIPTION
great library, thanks @marcocesarato! `yarpm` is only used during development as far as i can tell, can we move it to dev deps?