### PR TITLE
Fix type of itemHeight

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -63,7 +63,8 @@ interface BigListProps<ItemT>
   itemHeight:
     | string
     | number
-    | ((item: { index: number; section?: number }) => number);
+    | ((section: number) => number)
+    | ((section: number, index: number) => number);
   onScrollEnd?: (event: NativeSyntheticEvent<NativeScrollEvent>) => void;
   renderAccessory?: (list: React.ReactNode) => React.ReactNode;
   renderScrollViewWrapper?: (element: React.ReactNode) => React.ReactNode;


### PR DESCRIPTION
This fixes the typing of `itemHeight` according to the [docs](https://github.com/marcocesarato/react-native-big-list/blob/92114093b4ae0c12aef94be7bc56a66dcea06aeb/docs/docs/props.md?plain=1#L90) and what I've inferred from the code (e.g. in [`BigListProcessor`](https://github.com/marcocesarato/react-native-big-list/blob/92114093b4ae0c12aef94be7bc56a66dcea06aeb/lib/BigListProcessor.js#L280-L283)).