### PR TITLE
fix: regex-ify UNSAFE_ autobind

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -45,15 +45,13 @@ export const processBlock = ({
 export const autobind = (self = {}) => {
   const exclude = [
     "componentWillMount",
-    "UNSAFE_componentWillMount",
+    /UNSAFE_.*/,
     "render",
     "getSnapshotBeforeUpdate",
     "componentDidMount",
     "componentWillReceiveProps",
-    "UNSAFE_componentWillReceiveProps",
     "shouldComponentUpdate",
     "componentWillUpdate",
-    "UNSAFE_componentWillUpdate",
     "componentDidUpdate",
     "componentWillUnmount",
     "componentDidCatch",


### PR DESCRIPTION
It seems like the exclude list is designed with a particular react version in mind.
The code looks quite fragile and ideally you would autobind based on an allowlist rather than trying to bind everything and excluding stuff.