### PR TITLE
fix: allow overwriting elevation in style of section header

### DIFF
--- a/lib/BigListSection.jsx
+++ b/lib/BigListSection.jsx
@@ -49,11 +49,13 @@ const BigListSection = ({
       }),
     );
   const viewStyle = [
+    {
+      elevation: 10,
+    },
     React.isValidElement(child) && child.props.style
       ? child.props.style
       : style,
     {
-      elevation: 10,
       zIndex: 10,
       height: height,
       width: "100%",


### PR DESCRIPTION
_Not sure if this is a fix or a feature, but I don't think the change is big enough to be a feature._

I am experiencing some inconsistencies in the look of my section headers due to the elevation style property.

This PR allows developers to overwrite elevation without changing the look and functionality of the list for everybody who is happy with how the headers function today.

<img width="240" alt="Screenshot 2022-10-22 at 18 35 09" src="https://user-images.githubusercontent.com/6906782/197351183-cdda5b00-b1e9-46a6-bf40-5a0fd0779c58.png">

<img width="240" alt="Screenshot 2022-10-22 at 18 36 14" src="https://user-images.githubusercontent.com/6906782/197352032-da0ba387-b8fc-48c4-bdb0-eef144dd1672.png">

(Both screenshots show how the headers look on different Android devices with elevation set to 10)