### PR TITLE
feat: add support for native animation on scroll

### DIFF
--- a/docs/docs/props.md
+++ b/docs/docs/props.md
@@ -472,6 +472,18 @@ Hide footer on empty list.
 | ------- | -------- | ------- |
 | boolean | No       | `false` |
 
+### `nativeOffsetValues`
+
+Cast the content offset to animated values using the native driver on scroll.
+
+```ts
+nativeOffsetValues={{x?: Animated.Value, y?: Animated.Value}}
+```
+
+| Type                                             | Required | Default     |
+| ------------------------------------------------ | -------- | ----------- |
+| object: { x: Animated.Value, y: Animated.Value } | No       | `undefined` |
+
 ## <a name="flatlist"></a> FlatList Props
 
 :::caution Compatibility

--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -853,7 +853,7 @@ class BigList extends PureComponent {
    * Component did mount.
    */
   componentDidMount() {
-    const { stickySectionHeadersEnabled } = this.props;
+    const { stickySectionHeadersEnabled, nativeOffsetValues } = this.props;
     const scrollView = this.getNativeScrollRef();
     if (
       stickySectionHeadersEnabled &&
@@ -866,6 +866,15 @@ class BigList extends PureComponent {
         "onScroll",
         [{ nativeEvent: { contentOffset: { y: this.scrollTopValue } } }],
       );
+    }
+    if (nativeOffsetValues && scrollView != null && Platform.OS !== "web") {
+      Animated.attachNativeEvent(scrollView, "onScroll", [
+        {
+          nativeEvent: {
+            contentOffset: nativeOffsetValues,
+          },
+        },
+      ]);
     }
   }
 
@@ -1007,7 +1016,7 @@ class BigList extends PureComponent {
       defaultProps.contentContainerStyle,
     );
 
-    const ListScrollView = ScrollViewComponent || ScrollView;
+    const ListScrollView = ScrollViewComponent || Animated.ScrollView;
 
     const scrollView = wrapper(
       <ListScrollView {...scrollViewProps}>
@@ -1131,7 +1140,14 @@ BigList.propTypes = {
   ]),
   sections: PropTypes.array,
   stickySectionHeadersEnabled: PropTypes.bool,
-  ScrollViewComponent: PropTypes.oneOfType([PropTypes.func, PropTypes.elementType]),
+  nativeOffsetValues: PropTypes.shape({
+    x: PropTypes.instanceOf(Animated.Value),
+    y: PropTypes.instanceOf(Animated.Value),
+  }),
+  ScrollViewComponent: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.elementType,
+  ]),
 };
 
 BigList.defaultProps = {
@@ -1175,7 +1191,8 @@ BigList.defaultProps = {
   insetBottom: 0,
   contentInset: { top: 0, right: 0, left: 0, bottom: 0 },
   onEndReachedThreshold: 0,
-  ScrollViewComponent: ScrollView,
+  nativeOffsetValues: undefined,
+  ScrollViewComponent: Animated.ScrollView,
 };
 
 export default BigList;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -79,6 +79,7 @@ interface BigListProps<ItemT>
   sections?: ItemT[][] | null | undefined;
   stickySectionHeadersEnabled?: boolean;
   children?: null | undefined;
+  animatedOffsetValues?: { x?: Animated.Value, y?: Animated.Value };
   ScrollViewComponent?: React.ComponentType<ScrollViewProps> | React.Component<ScrollViewProps>;
 }
 export default class BigList<ItemT = any> extends PureComponent<

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -79,7 +79,7 @@ interface BigListProps<ItemT>
   sections?: ItemT[][] | null | undefined;
   stickySectionHeadersEnabled?: boolean;
   children?: null | undefined;
-  animatedOffsetValues?: { x?: Animated.Value, y?: Animated.Value };
+  nativeOffsetValues?: { x?: Animated.Value, y?: Animated.Value };
   ScrollViewComponent?: React.ComponentType<ScrollViewProps> | React.Component<ScrollViewProps>;
 }
 export default class BigList<ItemT = any> extends PureComponent<


### PR DESCRIPTION
This PR solves this issue: https://github.com/marcocesarato/react-native-big-list/issues/41

Using `onScroll` for setting an Animated.Value is very janky, because `useNativeDriver` has to be set to `false`. Setting it to `true` makes it not work at all.

I've introduced a new prop called **nativeOffsetValues**, which takes an object of `{x: Animated.Value, y: Animated.Value }`, and works like this:

```
const scrollY = useRef(new Animated.Value(0)).current;

return (
  <>
    <BigList
      nativeOffsetValues={{ y: props.scrollY }}
    />
    <Animated.View
      style={{
        opacity: scrollY.interpolate({
          inputRange: [0, 50],
          outputRange: [0, 1],
          extrapolate: "clamp",
        }),
      }}
    />
  </>
);
```