### PR TITLE
Stabilize the unstable empty component.

### DIFF
--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -682,13 +682,22 @@ class BigList extends PureComponent {
       width: "100%",
     });
 
+    const getEmpty = () => {
+      const props = {
+        key: 'empty',
+        style: fullItemStyle
+      };
+
+      return ListEmptyComponent
+        ? createElement(ListEmptyComponent, props)
+        : renderEmpty
+        ? createElement(renderEmpty(), props)
+        : null;
+    }
+
     // On empty list
     const isEmptyList = this.isEmpty();
-    const emptyItem = ListEmptyComponent
-      ? createElement(ListEmptyComponent)
-      : renderEmpty
-      ? renderEmpty()
-      : null;
+    const emptyItem = getEmpty();
     if (isEmptyList && emptyItem) {
       if (hideMarginalsOnEmpty || (hideHeaderOnEmpty && hideFooterOnEmpty)) {
         // Render empty
@@ -700,7 +709,6 @@ class BigList extends PureComponent {
         );
         items.splice(headerIndex + 1, 0, {
           type: BigListItemType.EMPTY,
-          key: "empty",
         });
         if (hideHeaderOnEmpty) {
           // Hide header
@@ -809,7 +817,7 @@ class BigList extends PureComponent {
           }
           break;
         case BigListItemType.EMPTY:
-          children.push(<View key={itemKey}>{emptyItem}</View>);
+          children.push(getEmpty());
           break;
         case BigListItemType.SPACER:
           children.push(
@@ -985,8 +993,6 @@ class BigList extends PureComponent {
           <RefreshControl refreshing={refreshing} onRefresh={onRefresh} />
         ) : null,
       contentContainerStyle: {
-        flexDirection: "row",
-        flexWrap: "wrap",
         maxWidth: "100%",
       },
     };

--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -683,10 +683,7 @@ class BigList extends PureComponent {
     });
 
     const getEmpty = () => {
-      const props = {
-        key: 'empty',
-        style: fullItemStyle
-      };
+      const props = {style: fullItemStyle};
 
       return ListEmptyComponent
         ? createElement(ListEmptyComponent, props)
@@ -709,6 +706,7 @@ class BigList extends PureComponent {
         );
         items.splice(headerIndex + 1, 0, {
           type: BigListItemType.EMPTY,
+          key: 'empty',
         });
         if (hideHeaderOnEmpty) {
           // Hide header
@@ -817,7 +815,11 @@ class BigList extends PureComponent {
           }
           break;
         case BigListItemType.EMPTY:
-          children.push(getEmpty());
+          children.push(
+            <React.Fragment key={itemKey}>
+              {getEmpty()}
+            </React.Fragment>
+          );
           break;
         case BigListItemType.SPACER:
           children.push(

--- a/lib/BigList.jsx
+++ b/lib/BigList.jsx
@@ -682,19 +682,14 @@ class BigList extends PureComponent {
       width: "100%",
     });
 
-    const getEmpty = () => {
-      const props = {style: fullItemStyle};
-
-      return ListEmptyComponent
-        ? createElement(ListEmptyComponent, props)
-        : renderEmpty
-        ? createElement(renderEmpty(), props)
-        : null;
-    }
-
     // On empty list
     const isEmptyList = this.isEmpty();
-    const emptyItem = getEmpty();
+    const emptyItem = ListEmptyComponent
+      ? createElement(ListEmptyComponent, {style: fullItemStyle})
+      : renderEmpty
+      ? createElement(renderEmpty(), {style: fullItemStyle})
+      : null;
+
     if (isEmptyList && emptyItem) {
       if (hideMarginalsOnEmpty || (hideHeaderOnEmpty && hideFooterOnEmpty)) {
         // Render empty
@@ -817,7 +812,7 @@ class BigList extends PureComponent {
         case BigListItemType.EMPTY:
           children.push(
             <React.Fragment key={itemKey}>
-              {getEmpty()}
+              {emptyItem}
             </React.Fragment>
           );
           break;

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -22,7 +22,7 @@ export type BigListRenderItem<ItemT> = (
   info: BigListRenderItemInfo<ItemT>,
 ) => React.ReactElement | null;
 
-interface BigListProps<ItemT>
+export interface BigListProps<ItemT>
   extends ScrollViewProps,
     Pick<
       FlatListProps<ItemT>,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -125,14 +125,15 @@ export const mergeViewStyle = (style, defaultStyle = {}) => {
 /**
  * Get element from component.
  * @param {React.node} Component
+ * @param props
  * @returns {JSX.Element|[]|*}
  */
-export const createElement = (Component) => {
+export const createElement = (Component, ...props) => {
   return Component != null ? (
     React.isValidElement(Component) ? (
       Component
     ) : (
-      <Component />
+      <Component {...props} />
     )
   ) : null;
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -128,7 +128,7 @@ export const mergeViewStyle = (style, defaultStyle = {}) => {
  * @param props
  * @returns {JSX.Element|[]|*}
  */
-export const createElement = (Component, ...props) => {
+export const createElement = (Component, props) => {
   return Component != null ? (
     React.isValidElement(Component) ? (
       React.cloneElement(Component, props)

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -131,7 +131,7 @@ export const mergeViewStyle = (style, defaultStyle = {}) => {
 export const createElement = (Component, ...props) => {
   return Component != null ? (
     React.isValidElement(Component) ? (
-      Component
+      React.cloneElement(Component, props)
     ) : (
       <Component {...props} />
     )


### PR DESCRIPTION
Simply put, making EmptyComponent more flexible. The following 3 parameters can cause EmptyComponent to take different styles.

```
hideMarginalsOnEmpty
hideHeaderOnEmpty
hideFooterOnEmpty
```

To solve this follow a way as HeaderComponent or FooterComponent is created. The style we give to renderEmpty or ListEmptyComponent will be one-to-one consistent.

**For example;**

```
<BigList
    data={[]}
    renderItem={() => <View />}
    itemHeight={50}
    style={{flexGrow: 1}}
    contentContainerStyle={{flexGrow: 1}}
    renderEmpty={() => {
        // It cannot fill the page. This situation has been corrected.
        return (
            <View style={{flexGrow: 1, backgroundColor: 'red'}} />
        )
    }}
/>
```

**Correction of the previously closed issue:** [https://github.com/marcocesarato/react-native-big-list/issues/83](https://github.com/marcocesarato/react-native-big-list/issues/83)